### PR TITLE
Feat/ Response Dto 변경 및 Controller&Service 메서드 반환타입 변경

### DIFF
--- a/src/main/java/sparta/ifour/movietalk/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,20 @@
+package sparta.ifour.movietalk.domain.comment.dto.response;
+
+import sparta.ifour.movietalk.domain.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+
+public class CommentResponseDto {
+
+
+    private Long id;
+    private String content;
+    private LocalDateTime createAt;
+
+    public CommentResponseDto(Comment comment) {
+        this.id = comment.getId();
+        this.content = comment.getContent();
+        this.createAt = comment.getCreatedAt();
+    }
+
+}

--- a/src/main/java/sparta/ifour/movietalk/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/comment/dto/response/CommentResponseDto.java
@@ -1,20 +1,22 @@
 package sparta.ifour.movietalk.domain.comment.dto.response;
 
+import lombok.Getter;
 import sparta.ifour.movietalk.domain.comment.entity.Comment;
 
 import java.time.LocalDateTime;
 
+@Getter
 public class CommentResponseDto {
 
 
     private Long id;
     private String content;
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
     public CommentResponseDto(Comment comment) {
         this.id = comment.getId();
         this.content = comment.getContent();
-        this.createAt = comment.getCreatedAt();
+        this.createdAt = comment.getCreatedAt();
     }
 
 }

--- a/src/main/java/sparta/ifour/movietalk/domain/reviews/controller/ReviewQueryController.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/reviews/controller/ReviewQueryController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sparta.ifour.movietalk.domain.reviews.dto.response.ReviewPreviewResponseDto;
 import sparta.ifour.movietalk.domain.reviews.dto.response.ReviewResponseDto;
 import sparta.ifour.movietalk.domain.reviews.service.ReviewService;
 
@@ -19,8 +20,8 @@ public class ReviewQueryController {
     private final ReviewService reviewService;
 
     @GetMapping("/reviews") //리뷰 전체 목록 조회
-    public ResponseEntity<List<ReviewResponseDto>> getAllReviews(){
-        List<ReviewResponseDto> reviewListAll = reviewService.getReviewsAll();
+    public ResponseEntity<List<ReviewPreviewResponseDto>> getAllReviews(){
+        List<ReviewPreviewResponseDto> reviewListAll = reviewService.getReviewsAll();
         return ResponseEntity.ok(reviewListAll);
     }
 
@@ -31,17 +32,17 @@ public class ReviewQueryController {
     }
 
     @GetMapping("/reviews/query/{queryName}") //리뷰 검색 목록 조회
-    public ResponseEntity<List<ReviewResponseDto>> getReviewsBySearch(@PathVariable String queryName){
+    public ResponseEntity<List<ReviewPreviewResponseDto>> getReviewsBySearch(@PathVariable String queryName){
 
-        List<ReviewResponseDto> reviewListBySearch = reviewService.getReviewsBySearch(queryName);
+        List<ReviewPreviewResponseDto> reviewListBySearch = reviewService.getReviewsBySearch(queryName);
 
         return ResponseEntity.ok(reviewListBySearch);
     }
 
     @GetMapping("reviews/hashtag/{hashtagName}") // 특정 해시태그가 포함된 리뷰 조회
-    public ResponseEntity<List<ReviewResponseDto>> getReviewsByHashTag(@PathVariable String hashtagName){
+    public ResponseEntity<List<ReviewPreviewResponseDto>> getReviewsByHashTag(@PathVariable String hashtagName){
 
-        List<ReviewResponseDto> reviewListByTag = reviewService.getReviewsByTag(hashtagName);
+        List<ReviewPreviewResponseDto> reviewListByTag = reviewService.getReviewsByTag(hashtagName);
 
         return ResponseEntity.ok(reviewListByTag);
 

--- a/src/main/java/sparta/ifour/movietalk/domain/reviews/controller/ReviewQueryController.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/reviews/controller/ReviewQueryController.java
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sparta.ifour.movietalk.domain.reviews.dto.response.ReviewDetailResponseDto;
 import sparta.ifour.movietalk.domain.reviews.dto.response.ReviewPreviewResponseDto;
-import sparta.ifour.movietalk.domain.reviews.dto.response.ReviewResponseDto;
 import sparta.ifour.movietalk.domain.reviews.service.ReviewService;
 
 import java.util.List;
@@ -26,8 +26,8 @@ public class ReviewQueryController {
     }
 
     @GetMapping("/reviews/{reviewId}") // 특정 리뷰 상세조회
-    public ResponseEntity<ReviewResponseDto> getReview(@PathVariable Long reviewId){
-        ReviewResponseDto reviewResponseDto = reviewService.getReview(reviewId);
+    public ResponseEntity<ReviewDetailResponseDto> getReview(@PathVariable Long reviewId){
+        ReviewDetailResponseDto reviewResponseDto = reviewService.getReview(reviewId);
         return ResponseEntity.ok(reviewResponseDto);
     }
 

--- a/src/main/java/sparta/ifour/movietalk/domain/reviews/dto/response/ReviewDetailResponseDto.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/reviews/dto/response/ReviewDetailResponseDto.java
@@ -3,6 +3,7 @@ package sparta.ifour.movietalk.domain.reviews.dto.response;
 import lombok.Getter;
 import sparta.ifour.movietalk.domain.comment.dto.response.CommentCreateResponseDto;
 import sparta.ifour.movietalk.domain.reviews.entity.Review;
+import sparta.ifour.movietalk.domain.reviews.entity.ReviewHashtag;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +18,8 @@ public class ReviewDetailResponseDto {
     private String content;
     private Float ratingScore;
     private String movieName;
+    private Integer countLikes;
+    private List<ReviewHashtag> reviewHashtagList;
     private LocalDateTime createdAt;
     private List<CommentCreateResponseDto> commentList;
 
@@ -28,5 +31,8 @@ public class ReviewDetailResponseDto {
         this.movieName = review.getMovieName();
         this.createdAt = review.getCreatedAt();
         this.commentList = commentList;
+        this.countLikes = review.getLikeList().size();
+        this.reviewHashtagList = review.getReviewHashtagList();
+
     }
 }

--- a/src/main/java/sparta/ifour/movietalk/domain/reviews/dto/response/ReviewDetailResponseDto.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/reviews/dto/response/ReviewDetailResponseDto.java
@@ -2,6 +2,7 @@ package sparta.ifour.movietalk.domain.reviews.dto.response;
 
 import lombok.Getter;
 import sparta.ifour.movietalk.domain.comment.dto.response.CommentCreateResponseDto;
+import sparta.ifour.movietalk.domain.comment.dto.response.CommentResponseDto;
 import sparta.ifour.movietalk.domain.reviews.entity.Review;
 import sparta.ifour.movietalk.domain.reviews.entity.ReviewHashtag;
 
@@ -21,18 +22,20 @@ public class ReviewDetailResponseDto {
     private Integer countLikes;
     private List<ReviewHashtag> reviewHashtagList;
     private LocalDateTime createdAt;
-    private List<CommentCreateResponseDto> commentList;
+    private List<CommentResponseDto> commentList;
 
-    public ReviewDetailResponseDto(Review review, List<CommentCreateResponseDto> commentList) {
+    public ReviewDetailResponseDto(Review review) {
         this.id = review.getId();
         this.title = review.getTitle();
         this.content = review.getContent();
         this.ratingScore = review.getRatingScore();
         this.movieName = review.getMovieName();
         this.createdAt = review.getCreatedAt();
-        this.commentList = commentList;
         this.countLikes = review.getLikeList().size();
         this.reviewHashtagList = review.getReviewHashtagList();
+        this.commentList = review.getCommentList().stream()
+                .map(CommentResponseDto::new)
+                .toList();
 
     }
 }

--- a/src/main/java/sparta/ifour/movietalk/domain/reviews/dto/response/ReviewPreviewResponseDto.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/reviews/dto/response/ReviewPreviewResponseDto.java
@@ -2,8 +2,10 @@ package sparta.ifour.movietalk.domain.reviews.dto.response;
 
 import lombok.Getter;
 import sparta.ifour.movietalk.domain.reviews.entity.Review;
+import sparta.ifour.movietalk.domain.reviews.entity.ReviewHashtag;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 목록 조회 관련 ResponseDto
@@ -16,7 +18,11 @@ public class ReviewPreviewResponseDto {
     private String content;
     private Float ratingScore;
     private String movieName;
+    private Integer countLikes;
+    private List<ReviewHashtag> reviewHashtagList;
     private LocalDateTime createdAt;
+
+
 
     public ReviewPreviewResponseDto(Review review){
         this.id = review.getId();
@@ -25,5 +31,7 @@ public class ReviewPreviewResponseDto {
         this.ratingScore = review.getRatingScore();
         this.movieName = review.getMovieName();
         this.createdAt = review.getCreatedAt();
+        this.reviewHashtagList = review.getReviewHashtagList();
+        this.countLikes = review.getLikeList().size();
     }
 }

--- a/src/main/java/sparta/ifour/movietalk/domain/reviews/dto/response/ReviewResponseDto.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/reviews/dto/response/ReviewResponseDto.java
@@ -4,8 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import sparta.ifour.movietalk.domain.reviews.entity.Review;
+import sparta.ifour.movietalk.domain.reviews.entity.ReviewHashtag;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -21,6 +23,10 @@ public class ReviewResponseDto {
 
     private String movieName;
 
+    private Integer countLikes;
+
+    private List<ReviewHashtag> reviewHashtagList;
+
     private LocalDateTime createdAt;
 
 
@@ -31,6 +37,8 @@ public class ReviewResponseDto {
         this.ratingScore = review.getRatingScore();
         this.movieName = review.getMovieName();
         this.createdAt = review.getCreatedAt();
+        this.countLikes = review.getLikeList().size();
+        this.reviewHashtagList = review.getReviewHashtagList();
     }
 
 

--- a/src/main/java/sparta/ifour/movietalk/domain/reviews/entity/Review.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/reviews/entity/Review.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
+import sparta.ifour.movietalk.domain.comment.entity.Comment;
 import sparta.ifour.movietalk.domain.model.BaseEntity;
 import sparta.ifour.movietalk.domain.user.entity.User;
 
@@ -47,6 +48,9 @@ public class Review extends BaseEntity {
 
     @OneToMany(mappedBy = "review")
     private List<Like> likeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "review")
+    private  List<Comment> commentList = new ArrayList<>();
 
     @Builder
     public Review(String title, String content, Float ratingScore, String movieName) {

--- a/src/main/java/sparta/ifour/movietalk/domain/reviews/service/ReviewService.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/reviews/service/ReviewService.java
@@ -82,32 +82,32 @@ public class ReviewService {
 
     }
 
-    public List<ReviewResponseDto> getReviewsAll() {
+    public List<ReviewPreviewResponseDto> getReviewsAll() {
 
         List<Review> reviewListAll = reviewRepository.findAll();
 
         return reviewListAll.stream()
-                .map(ReviewResponseDto::new)
+                .map(ReviewPreviewResponseDto::new)
                 .toList();
 
     }
 
-    public List<ReviewResponseDto> getReviewsBySearch(String queryname) {
+    public List<ReviewPreviewResponseDto> getReviewsBySearch(String queryname) {
 
         return reviewRepository.findAll()
                 .stream()
                 .filter(review -> doesReviewContain(queryname, review))
-                .map(ReviewResponseDto::new)
+                .map(ReviewPreviewResponseDto::new)
                 .toList();
 
     }
 
-    public List<ReviewResponseDto> getReviewsByTag(String hashtagName) {
+    public List<ReviewPreviewResponseDto> getReviewsByTag(String hashtagName) {
         Hashtag hashtag = getHashtagByname(hashtagName);
 
         return hashtag.getReviewHashtagList().stream()
                 .map(ReviewHashtag::getReview)
-                .map(ReviewResponseDto::new)
+                .map(ReviewPreviewResponseDto::new)
                 .toList();
     }
 

--- a/src/main/java/sparta/ifour/movietalk/domain/reviews/service/ReviewService.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/reviews/service/ReviewService.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sparta.ifour.movietalk.domain.reviews.dto.request.ReviewRequestDto;
+import sparta.ifour.movietalk.domain.reviews.dto.response.ReviewDetailResponseDto;
 import sparta.ifour.movietalk.domain.reviews.dto.response.ReviewPreviewResponseDto;
-import sparta.ifour.movietalk.domain.reviews.dto.response.ReviewResponseDto;
 import sparta.ifour.movietalk.domain.reviews.entity.Hashtag;
 import sparta.ifour.movietalk.domain.reviews.entity.Like;
 import sparta.ifour.movietalk.domain.reviews.entity.Review;
@@ -74,11 +74,11 @@ public class ReviewService {
         }
     }
 
-    public ReviewResponseDto getReview(Long reviewId) {
+    public ReviewDetailResponseDto getReview(Long reviewId) {
 
         Review review = getReviewById(reviewId);
 
-        return new ReviewResponseDto(review);
+        return new ReviewDetailResponseDto(review);
 
     }
 


### PR DESCRIPTION
## 개요
조회 메서드 실행시 반환ResponseDto에 좋아요 및 해쉬태그 반환 & Controller 및 해당 Service 메서드 반환타입 변경 


## 작업사항

리뷰 조회시 좋아요와 해쉬태그를 포함해서 반환하도록  Dto변경

 QueryController & 및 해당 ReviewService 메서드 반환타입 Detail용과 Preview용으로 수정

ReviewResponseDto 삭제

Review에 commentList 추가


## 변경로직

QueryController에 기존에 ReviewResponseDto로 통일된걸 DetailsDto와 PreviewDto용 으로 나눴습니다.


