### PR TITLE
Fix/comment api edit

### DIFF
--- a/src/main/java/sparta/ifour/movietalk/domain/comment/controller/CommentController.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/comment/controller/CommentController.java
@@ -17,9 +17,9 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("/{reviewId}")
-    public ResponseEntity<CommentCreateResponseDto> createComment(@RequestBody CommentCreateRequestDto requestDto, @PathVariable Long reviewId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        CommentCreateResponseDto responseDto = commentService.createComment(requestDto, userDetails.getUser(), reviewId);
+    @PostMapping("")
+    public ResponseEntity<CommentCreateResponseDto> createComment(@RequestBody CommentCreateRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CommentCreateResponseDto responseDto = commentService.createComment(requestDto, userDetails.getUser());
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/sparta/ifour/movietalk/domain/comment/controller/CommentController.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/comment/controller/CommentController.java
@@ -4,11 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import sparta.ifour.movietalk.domain.comment.dto.request.CommentUpdateRequestDto;
 import sparta.ifour.movietalk.domain.comment.dto.request.CommentCreateRequestDto;
+import sparta.ifour.movietalk.domain.comment.dto.request.CommentUpdateRequestDto;
 import sparta.ifour.movietalk.domain.comment.dto.response.CommentCreateResponseDto;
 import sparta.ifour.movietalk.domain.comment.service.CommentService;
-import sparta.ifour.movietalk.domain.user.entity.User;
+import sparta.ifour.movietalk.global.config.security.UserDetailsImpl;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,20 +18,20 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("/{reviewId}")
-    public ResponseEntity<CommentCreateResponseDto> createComment(@RequestBody CommentCreateRequestDto requestDto, @PathVariable Long reviewId, @AuthenticationPrincipal User user) {
-        CommentCreateResponseDto responseDto = commentService.createComment(requestDto, user, reviewId);
+    public ResponseEntity<CommentCreateResponseDto> createComment(@RequestBody CommentCreateRequestDto requestDto, @PathVariable Long reviewId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CommentCreateResponseDto responseDto = commentService.createComment(requestDto, userDetails.getUser(), reviewId);
         return ResponseEntity.ok(responseDto);
     }
 
     @PatchMapping("/{commentId}")
-    public ResponseEntity<?> updateComment(@RequestBody CommentUpdateRequestDto requestDto, @PathVariable Long commentId, @AuthenticationPrincipal User user) {
-        commentService.updateComment(requestDto, commentId, user);
+    public ResponseEntity<?> updateComment(@RequestBody CommentUpdateRequestDto requestDto, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.updateComment(requestDto, commentId, userDetails.getUser());
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<?> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal User user) {
-        commentService.deleteComment(commentId, user);
+    public ResponseEntity<?> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.deleteComment(commentId, userDetails.getUser());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/sparta/ifour/movietalk/domain/comment/controller/CommentController.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/comment/controller/CommentController.java
@@ -18,19 +18,29 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("")
-    public ResponseEntity<CommentCreateResponseDto> createComment(@RequestBody CommentCreateRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<CommentCreateResponseDto> createComment(
+            @RequestBody CommentCreateRequestDto requestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
         CommentCreateResponseDto responseDto = commentService.createComment(requestDto, userDetails.getUser());
         return ResponseEntity.ok(responseDto);
     }
 
     @PatchMapping("/{commentId}")
-    public ResponseEntity<?> updateComment(@RequestBody CommentUpdateRequestDto requestDto, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<?> updateComment(
+            @RequestBody CommentUpdateRequestDto requestDto,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
         commentService.updateComment(requestDto, commentId, userDetails.getUser());
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<?> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<?> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
         commentService.deleteComment(commentId, userDetails.getUser());
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/sparta/ifour/movietalk/domain/comment/dto/request/CommentCreateRequestDto.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/comment/dto/request/CommentCreateRequestDto.java
@@ -1,6 +1,7 @@
 package sparta.ifour.movietalk.domain.comment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,5 +13,8 @@ public class CommentCreateRequestDto {
     @Size(max = 100)
     @NotBlank
     private String content;
+
+    @NotNull
+    private Long reviewId;
 
 }

--- a/src/main/java/sparta/ifour/movietalk/domain/comment/service/CommentService.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/comment/service/CommentService.java
@@ -23,7 +23,8 @@ public class CommentService {
     private final ReviewRepository reviewRepository;
 
     public CommentCreateResponseDto createComment(CommentCreateRequestDto requestDto, User user) {
-        Review review = reviewRepository.findById(requestDto.getReviewId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다."));
+        Review review = reviewRepository.findById(requestDto.getReviewId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다."));
         Comment comment = Comment.create(requestDto.getContent(), user, review);
         commentRepository.save(comment);
         return new CommentCreateResponseDto(comment);
@@ -40,7 +41,8 @@ public class CommentService {
     }
 
     private Comment getUserComment(Long commentId, User user) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
 
         if (!comment.getUser().getId().equals(user.getId())) {
             throw new RejectedExecutionException("본인의 댓글만 수정이 가능합니다.");

--- a/src/main/java/sparta/ifour/movietalk/domain/comment/service/CommentService.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/comment/service/CommentService.java
@@ -22,8 +22,8 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final ReviewRepository reviewRepository;
 
-    public CommentCreateResponseDto createComment(CommentCreateRequestDto requestDto, User user, Long reviewId) {
-        Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다."));
+    public CommentCreateResponseDto createComment(CommentCreateRequestDto requestDto, User user) {
+        Review review = reviewRepository.findById(requestDto.getReviewId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다."));
         Comment comment = Comment.create(requestDto.getContent(), user, review);
         commentRepository.save(comment);
         return new CommentCreateResponseDto(comment);


### PR DESCRIPTION
## 개요
댓글 생성시 reviewId 전달 받는 방식을 기존 PathVariable 에서 Body로 변경,
댓글 기능 인증/인가 필요한 기능에서 매개 변수를 User에서 UserDetails로 변경

## 작업사항
- reviewId 전달 PathVariable -> Body
- 댓글 컨트롤러에서 매개변수를 User -> UserDetails로 변경

## 변경로직
- 댓글 컨트롤러 모든 메소드에서 파라미터를 User -> UserDetails로 변경
- 댓글 컨트롤러 댓글 생성 메소드에서 Path {reviewId}제거
- 댓글 컨트롤러 댓글 생성 메소드에서 서비스로 넘기는 인자에서 reviewId 제거
- 댓글 서비스 댓글 생성 메소드 파라미터에서 reviewId 제거
- 댓글 생성 요청 DTO에 reviewId 필드 추가
- 댓글 서비스에서 리뷰 찾을 때 인자 reviewId -> requestDto.getReviewId()로 변경

## 관련 이슈
- #40 
