### PR TITLE
Feat/add user edit api

### DIFF
--- a/src/main/java/sparta/ifour/movietalk/domain/user/controller/UserController.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/user/controller/UserController.java
@@ -53,7 +53,7 @@ public class UserController {
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@Valid @RequestBody UserPasswordUpdateRequestDto requestDto) {
 
-		userService.updatePassword(userDetails.getUser(), requestDto);
+		userService.updatePassword(userDetails.getUsername(), requestDto);
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/sparta/ifour/movietalk/domain/user/controller/UserController.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/user/controller/UserController.java
@@ -1,14 +1,21 @@
 package sparta.ifour.movietalk.domain.user.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import sparta.ifour.movietalk.domain.user.dto.request.UserPasswordUpdateRequestDto;
+import sparta.ifour.movietalk.domain.user.dto.request.UserProfileUpdateRequestDto;
 import sparta.ifour.movietalk.domain.user.dto.response.UserProfileResponseDto;
 import sparta.ifour.movietalk.domain.user.service.UserService;
+import sparta.ifour.movietalk.global.config.security.UserDetailsImpl;
 
 /**
  * 인증을 제외한 유저 관련 컨트롤러
@@ -29,5 +36,25 @@ public class UserController {
 		UserProfileResponseDto responseDto = userService.getProfile(nickname);
 
 		return ResponseEntity.ok(responseDto);
+	}
+
+	@PatchMapping("/profile")
+	public ResponseEntity<?> updateProfile(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@Valid @RequestBody UserProfileUpdateRequestDto requestDto) {
+
+		userService.updateProfile(userDetails.getUser(), requestDto);
+
+		return ResponseEntity.ok().build();
+	}
+
+	@PatchMapping("/password")
+	public ResponseEntity<?> updatePassword(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@Valid @RequestBody UserPasswordUpdateRequestDto requestDto) {
+
+		userService.updatePassword(userDetails.getUser(), requestDto);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/sparta/ifour/movietalk/domain/user/service/AuthService.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/user/service/AuthService.java
@@ -1,5 +1,6 @@
 package sparta.ifour.movietalk.domain.user.service;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ import sparta.ifour.movietalk.global.config.security.jwt.JwtUtil;
 public class AuthService {
 
 	private final JwtUtil jwtUtil;
+	private final PasswordEncoder passwordEncoder;
 	private final UserRepository userRepository;
 
 	/**
@@ -30,6 +32,8 @@ public class AuthService {
 	public void signup(UserSignupRequestDto requestDto) {
 
 		validateDuplicateId(requestDto);
+
+		requestDto.setPassword(passwordEncoder.encode(requestDto.getPassword()));
 		User user = User.create(requestDto);
 
 		userRepository.save(user);
@@ -56,7 +60,7 @@ public class AuthService {
 	}
 
 	private void validatePassword(String rawPassword, String userPassword) {
-		if (!userPassword.equals(rawPassword)) {
+		if (!passwordEncoder.matches(rawPassword, userPassword)) {
 			throw new IllegalArgumentException("잘못된 비밀번호");
 		}
 	}

--- a/src/main/java/sparta/ifour/movietalk/global/config/security/UserDetailsImpl.java
+++ b/src/main/java/sparta/ifour/movietalk/global/config/security/UserDetailsImpl.java
@@ -18,7 +18,7 @@ public class UserDetailsImpl implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		return user.getLoginId();
+		return user.getNickname();
 	}
 
 	@Override

--- a/src/main/java/sparta/ifour/movietalk/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/sparta/ifour/movietalk/global/config/security/WebSecurityConfig.java
@@ -52,6 +52,7 @@ public class WebSecurityConfig {
 		http.authorizeHttpRequests(authz -> authz
 			.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 			// 유저 도메인
+			.requestMatchers(HttpMethod.GET, "/api/users/{nickname}").permitAll()
 			.requestMatchers(HttpMethod.PATCH, "/api/users/profile", "/api/users/password").authenticated()
 			.requestMatchers("/api/users/**").permitAll()
 			// 댓글 도메인


### PR DESCRIPTION
## 개요
유저 정보 수정 API 추가 

## 작업사항
- 인증 객체를 nickname 으로 찾도록 수정
- 비밀번호 암호화 추가 
- 암호화된 비밀번호로 검증 추가 
- 프로필 조회는 인증 인가 없이 조회하도록 수정 
- 유저 정보 수정 API 추가 

## 변경로직
- 인증 객체를 nickname 으로 검색하도록 수정 
- 비밀번호를 BCrypt 알고리즘으로 암호화

## 관련 이슈
- #38 
