### PR TITLE
Fix/edit profile api

### DIFF
--- a/src/main/java/sparta/ifour/movietalk/domain/user/controller/UserController.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/user/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@Valid @RequestBody UserProfileUpdateRequestDto requestDto) {
 
-		userService.updateProfile(userDetails.getUser(), requestDto);
+		userService.updateProfile(userDetails.getUsername(), requestDto);
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/sparta/ifour/movietalk/domain/user/repository/UserRepository.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/user/repository/UserRepository.java
@@ -12,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByNickname(String nickname);
 
 	boolean existsByLoginIdOrNickname(String loginId, String nickname);
+	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/sparta/ifour/movietalk/global/config/security/jwt/JwtFilter.java
+++ b/src/main/java/sparta/ifour/movietalk/global/config/security/jwt/JwtFilter.java
@@ -32,14 +32,15 @@ public class JwtFilter extends OncePerRequestFilter {
 
 	private final JwtUtil jwtUtil;
 	private final UserDetailsService userDetailsService;
-	private static final RequestMatcher ignoredPaths = new AntPathRequestMatcher("/api/users/{nickname}", HttpMethod.GET.name());
+	private static final RequestMatcher userIgnoredPath = new AntPathRequestMatcher("/api/users/{nickname}", HttpMethod.GET.name());
+	private static final RequestMatcher reviewIgnoredPath = new AntPathRequestMatcher("/api/reviews/**", HttpMethod.GET.name());
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws
 		ServletException,
 		IOException {
 
-		if (ignoredPaths.matches(request)) {
+		if (userIgnoredPath.matches(request) || reviewIgnoredPath.matches(request)) {
 			filterChain.doFilter(request, response);
 			return;
 		}

--- a/src/main/java/sparta/ifour/movietalk/global/config/security/jwt/JwtFilter.java
+++ b/src/main/java/sparta/ifour/movietalk/global/config/security/jwt/JwtFilter.java
@@ -3,12 +3,15 @@ package sparta.ifour.movietalk.global.config.security.jwt;
 import java.io.IOException;
 import java.util.List;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -29,11 +32,17 @@ public class JwtFilter extends OncePerRequestFilter {
 
 	private final JwtUtil jwtUtil;
 	private final UserDetailsService userDetailsService;
+	private static final RequestMatcher ignoredPaths = new AntPathRequestMatcher("/api/users/{nickname}", HttpMethod.GET.name());
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws
 		ServletException,
 		IOException {
+
+		if (ignoredPaths.matches(request)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
 
 		String tokenValue = request.getHeader(JwtUtil.AUTHORIZATION_HEADER); // 헤더에서 JWT 가져오기
 		log.info("tokenValue : {}", tokenValue);


### PR DESCRIPTION
## 개요
프로필 수정 API 내부 구현 수정 및 JWT 검증 필요없는 API에서 검증하지 않도록 수정 

## 작업사항
- 유저 서비스에서 프로필 수정 메서드가 닉네임 파라미터를 받도록 수정
- 리뷰 및 유저 프로필 조회 시 JWT 검증 안 하도록 수정 

## 변경로직
- 유저 서비스에서 프로필 수정 메서드가 유저 엔티티에서 닉네임을 받도록 수정

## 관련 이슈
- #46 
