### PR TITLE
fix : 댓글 엔티티 연관관계 nullable false로 수정

### DIFF
--- a/src/main/java/sparta/ifour/movietalk/domain/comment/entity/Comment.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/comment/entity/Comment.java
@@ -20,11 +20,11 @@ public class Comment extends BaseEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_id")
+    @JoinColumn(name = "review_id", nullable = false)
     private Review review;
 
     private Comment(String content, User user, Review review) {


### PR DESCRIPTION
## 개요
댓글 엔티티 연관관계에 nullable 옵션을 안 적어놨었어서 false로 수정했습니다.

## 작업사항
- 댓글 엔티티 연관관계 필드 nullable = false로 수정

## 변경로직
- 댓글 엔티티 user 필드 nullable = false로 수정
- 댓글 엔티티 review 필드 nullable = false로 수정

## 관련 이슈
- 
