### PR TITLE
Fix/review tag

### DIFF
--- a/src/main/java/sparta/ifour/movietalk/domain/review/dto/response/ReviewDetailResponseDto.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/review/dto/response/ReviewDetailResponseDto.java
@@ -15,23 +15,27 @@ import java.util.List;
 public class ReviewDetailResponseDto {
     private Long id;
     private String title;
+    private String authorName;
     private String content;
     private Float ratingScore;
     private String movieName;
     private Integer countLikes;
-    private List<ReviewHashtag> reviewHashtagList;
+    private List<String> hashtagNameList;
     private LocalDateTime createdAt;
     private List<CommentResponseDto> commentList;
 
     public ReviewDetailResponseDto(Review review) {
         this.id = review.getId();
         this.title = review.getTitle();
+        this.authorName = review.getUser().getNickname();
         this.content = review.getContent();
         this.ratingScore = review.getRatingScore();
         this.movieName = review.getMovieName();
         this.createdAt = review.getCreatedAt();
         this.countLikes = review.getLikeList().size();
-        this.reviewHashtagList = review.getReviewHashtagList();
+        this.hashtagNameList = review.getReviewHashtagList().stream()
+                .map(reviewHashtag -> reviewHashtag.getHashtag().getName())
+                .toList();
         this.commentList = review.getCommentList().stream()
                 .map(CommentResponseDto::new)
                 .toList();

--- a/src/main/java/sparta/ifour/movietalk/domain/review/dto/response/ReviewPreviewResponseDto.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/review/dto/response/ReviewPreviewResponseDto.java
@@ -1,6 +1,7 @@
 package sparta.ifour.movietalk.domain.review.dto.response;
 
 import lombok.Getter;
+import sparta.ifour.movietalk.domain.review.entity.Hashtag;
 import sparta.ifour.movietalk.domain.review.entity.Review;
 import sparta.ifour.movietalk.domain.review.entity.ReviewHashtag;
 
@@ -19,7 +20,7 @@ public class ReviewPreviewResponseDto {
     private Float ratingScore;
     private String movieName;
     private Integer countLikes;
-    private List<ReviewHashtag> reviewHashtagList;
+    private List<String> hashtagNameList;
     private LocalDateTime createdAt;
 
 
@@ -31,7 +32,9 @@ public class ReviewPreviewResponseDto {
         this.ratingScore = review.getRatingScore();
         this.movieName = review.getMovieName();
         this.createdAt = review.getCreatedAt();
-        this.reviewHashtagList = review.getReviewHashtagList();
+        this.hashtagNameList = review.getReviewHashtagList().stream()
+                .map(reviewHashtag -> reviewHashtag.getHashtag().getName())
+                .toList();
         this.countLikes = review.getLikeList().size();
     }
 }

--- a/src/main/java/sparta/ifour/movietalk/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/sparta/ifour/movietalk/domain/review/service/ReviewCommandService.java
@@ -53,7 +53,10 @@ public class ReviewCommandService {
 			.forEach(tag -> {
 				ReviewHashtag reviewHashtag = new ReviewHashtag(review, tag);
 				reviewHashTagRepository.save(reviewHashtag);
+				review.addReviewHashtag(reviewHashtag);
+				tag.addReviewHashtag(reviewHashtag);
 			});
+
 
 
 


### PR DESCRIPTION
## 개요
리뷰조회시 해쉬태그가 원할하게 조회되지 않았던 부분 수정 

## 작업사항
ReviewResponseDto 부분에서 해쉬태그 이름 Stirng타입의 리스트를 필드로 가지도록 변경
Review생성시 Review와 tag에 addReviewHashtag실행되도록 추가 


 
